### PR TITLE
Disable scroll to top when filtering

### DIFF
--- a/components/Searchbar.tsx
+++ b/components/Searchbar.tsx
@@ -55,7 +55,7 @@ const SearchBar = () => {
     // Generate the new pathname with the updated search parameters
     const newPathname = `${window.location.pathname}?${searchParams.toString()}`;
 
-    router.push(newPathname);
+    router.push(newPathname, { scroll: false });
   };
 
   return (


### PR DESCRIPTION
It's a bit annoying whenever the filter applies it scrolls to the top instead of seeing the results instantly. 
Add { scroll: false } to router.push() to improve UX