### PR TITLE
Fix: display images on CarCard components correctly

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -74,7 +74,7 @@ export const generateCarImageUrl = (car: CarProps, angle?: string) => {
   url.searchParams.append('zoomType', 'fullscreen');
   url.searchParams.append('modelYear', `${year}`);
   // url.searchParams.append('zoomLevel', zoomLevel);
-  url.searchParams.append('angle', `${angle}`);
+  angle && url.searchParams.append('angle', `${angle}`);
 
   return `${url}`;
 } 


### PR DESCRIPTION
# Description
- to resolve a problem about displaying images on CarCard

# Problem
- Images of CarCard.tsx are not be displayed correctly

![broken_Images](https://github.com/adrianhajdin/project_next13_car_showcase/assets/37829927/812a33bc-2bc2-4d64-821a-e07d38b146c2)


# Cause
-  Images from cdn.imagin.studio API were not displayed well, when there were 'angle' params and those values were 'undefined'
- the method of append() returns 'undefined' when there is no value
(https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/append)
- From CarCard.tsx
`<Image src={generateCarImageUrl(car)} alt='car model' fill priority className='object-contain' />`

(Before deleting angle=undefined)
![undefined_angle](https://github.com/adrianhajdin/project_next13_car_showcase/assets/37829927/272d1eae-ea1b-4ccf-8538-f222e96fe5e0)

(After deleting angle=undefined)
![detach_undefined_angle](https://github.com/adrianhajdin/project_next13_car_showcase/assets/37829927/dd048f9b-039c-428e-a3ba-9ebbe1c661d9)

# Todo
- to append angle parameter only when it exists

# Result
![result](https://github.com/adrianhajdin/project_next13_car_showcase/assets/37829927/30b8d896-725d-42ee-b13d-ee2627ac0d6b)

I don't think if this is the best way to resolve this problem, but I wanted to share it.